### PR TITLE
feat(ci): add `npm` caching in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,6 @@ jobs:
         with:
           node-version: 16
           cache: "npm"
-          cache-dependency-path: "package-lock.json"
       - run: npm ci
       - run: npm run lint
       - uses: GabrielBB/xvfb-action@master

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,8 @@ jobs:
       - uses: actions/setup-node@master
         with:
           node-version: 16
+          cache: "npm"
+          cache-dependency-path: "package-lock.json"
       - run: npm ci
       - run: npm run lint
       - uses: GabrielBB/xvfb-action@master


### PR DESCRIPTION
Changes made by this PR can be summarized as follows:

- Set the `cache` and `cache-dependency-path` argument to enable caching to speed up CI times.