### PR TITLE
Use arm64 micromamba for Apple Silicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ generated-icons/
 *.vsix
 tmp
 .idea
+
+/.micromamba/

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "istanbul-lib-coverage": "^3.2.0",
         "istanbul-lib-source-maps": "^4.0.1",
         "jest": "^29.5.0",
+        "mock-os": "^1.0.0",
         "prettier": "^2.8.6",
         "rimraf": "^4.4.0",
         "ts-jest": "^29.0.5",
@@ -4845,6 +4846,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/mock-os": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mock-os/-/mock-os-1.0.0.tgz",
+      "integrity": "sha512-F2q8Vn6Md1cYN82K+MUMWLTmfs0FJVTjOLwvUPfy1JhFPaRoZ2zqludym9oZGxYLl81elOrIZvinZDvTX/llMg==",
+      "dev": true
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -9801,6 +9808,12 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+    },
+    "mock-os": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mock-os/-/mock-os-1.0.0.tgz",
+      "integrity": "sha512-F2q8Vn6Md1cYN82K+MUMWLTmfs0FJVTjOLwvUPfy1JhFPaRoZ2zqludym9oZGxYLl81elOrIZvinZDvTX/llMg==",
+      "dev": true
     },
     "ms": {
       "version": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "istanbul-lib-coverage": "^3.2.0",
     "istanbul-lib-source-maps": "^4.0.1",
     "jest": "^29.5.0",
+    "mock-os": "^1.0.0",
     "prettier": "^2.8.6",
     "rimraf": "^4.4.0",
     "ts-jest": "^29.0.5",

--- a/src/micromamba/downloadMicromamba.test.ts
+++ b/src/micromamba/downloadMicromamba.test.ts
@@ -1,4 +1,7 @@
 import * as path from 'path'
+import { spawnSync } from 'child_process'
+import mockos from 'mock-os'
+import { platform } from 'os'
 import sh from '../sh'
 import {
   downloadMicromambaLinux,
@@ -10,8 +13,12 @@ const tmpDir = path.join(__dirname, 'tmp', path.basename(__filename))
 
 describe('downloadMicromamba', () => {
   beforeEach(async () => {
+    mockos.restore()
     await sh.rmrf(tmpDir)
     await sh.mkdirp(tmpDir)
+  })
+  afterEach(() => {
+    mockos.restore()
   })
 
   it('win32', async () => {
@@ -26,9 +33,35 @@ describe('downloadMicromamba', () => {
     expect(actual).toEqual(['micromamba'])
   }, 10000)
 
-  it('darwin', async () => {
+  const getFileInfo = (filePath: string) => {
+    const res = spawnSync('file', [filePath], { encoding: 'utf8' })
+    expect(res.error).toBeUndefined()
+    expect(res.status).toEqual(0)
+    return res.stdout
+  }
+
+  it('darwin-x64', async () => {
+    mockos({ arch: 'x64' })
     await downloadMicromambaMac(tmpDir)
     const actual = await sh.ls(tmpDir)
     expect(actual).toEqual(['micromamba'])
+
+    if (platform() == 'darwin') {
+      expect(getFileInfo(path.join(tmpDir, 'micromamba'))).toContain(
+        'Mach-O 64-bit executable x86_64',
+      )
+    }
+  }, 10000)
+
+  it('darwin-arm64', async () => {
+    mockos({ arch: 'arm64' })
+    await downloadMicromambaMac(tmpDir)
+    const actual = await sh.ls(tmpDir)
+    expect(actual).toEqual(['micromamba'])
+    if (platform() == 'darwin') {
+      expect(getFileInfo(path.join(tmpDir, 'micromamba'))).toContain(
+        'Mach-O 64-bit executable arm64',
+      )
+    }
   }, 10000)
 })

--- a/src/micromamba/downloadMicromamba.ts
+++ b/src/micromamba/downloadMicromamba.ts
@@ -5,6 +5,7 @@ import * as tar from 'tar'
 import bz2 from 'unbzip2-stream'
 import { URL } from 'url'
 import sh from '../sh'
+import * as os from 'os'
 
 export const _downloadMicromamba = async (url: string, tar: Writable): Promise<void> => {
   try {
@@ -54,8 +55,22 @@ export const downloadMicromambaWin = async (cwd: string): Promise<void> => {
   await _downloadMicromamba(url, stream)
 }
 
+const makeMacDownloadArch = (): string => {
+  const arch = os.arch()
+  switch (arch) {
+    case 'x64':
+      return '64'
+
+    case 'arm64':
+      return arch
+
+    default:
+      throw new Error(`${arch} CPU architecture is not supported by micromamba`)
+  }
+}
+
 export const downloadMicromambaMac = async (cwd: string): Promise<void> => {
-  const url = 'https://micromamba.snakepit.net/api/micromamba/osx-64/latest'
+  const url = `https://micromamba.snakepit.net/api/micromamba/osx-${makeMacDownloadArch()}/latest`
   const stream = tar.x({ cwd, strip: 1 }, ['bin/micromamba'])
   await _downloadMicromamba(url, stream)
   await sh.chmodR('755', cwd)

--- a/tests/mock-os.d.ts
+++ b/tests/mock-os.d.ts
@@ -1,0 +1,1 @@
+declare module 'mock-os'


### PR DESCRIPTION
Issue:
It is best to use native architecture for the Apple Silicon if available. For some native binaries, e.g. pytorch, it is critical to use correct architecture, due to the use of architecture specific CPU extensions in the builds

Solution:
Extend download functions for mac to match CPU architecture of VSCode Update tests to download x64 and arm64
Add downloaded binary architecture check for macOS

Note:
I have explored using [`file-type`](https://www.npmjs.com/package/file-type) package for checking file on all the platforms. The package is capable of identifying needed architectures for linux and windows, it doesn't work for macOS. Moreover it is ESM only package and doesn't work in this repo which is using CJS