### PR TITLE
Limit extension activation events

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "workspace"
   ],
   "activationEvents": [
-    "*"
+    "workspaceContains:environment*.{yml,yaml}"
   ],
   "contributes": {
     "commands": [


### PR DESCRIPTION
Currently activation event is set to `*` which makes extension always active.
This results in extension always showing `Micromamba: Open a folder or a workspace` on startup
And extension will attempt to activate for every workspace even if it has no environment file consuming memory and CPU.

Extension packaging with `vcse` confirms this with the following warning:
```
 WARNING  Using '*' activation is usually a bad idea as it impacts performance.
More info: https://code.visualstudio.com/api/references/activation-events#Start-up
```

By limiting `activationEvents` to `workspaceContains:environment*.{yml,yaml}` extension will remain out of memory unless there is an environment file it can read to activate it. All the commands extension provides are still available and extension will be activate upon command execution:
```
2024-07-24 18:43:22.918 [info] ExtensionService#_doActivateExtension corker.vscode-micromamba, startup: false, activationEvent: 'onCommand:corker.micromamba.activate.environment.by.path'
```